### PR TITLE
Make FetchContent compatiable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,6 @@ if (POLICY CMP0091)
     endif ()
 endif ()
 
-set(generatedSourcesDir "${CMAKE_BINARY_DIR}/generated")
-set(fmuResultDir "${CMAKE_BINARY_DIR}/models")
-
 file(MAKE_DIRECTORY ${generatedSourcesDir})
 file(MAKE_DIRECTORY ${fmuResultDir})
 

--- a/cmake/generate_fmu.cmake
+++ b/cmake/generate_fmu.cmake
@@ -10,6 +10,16 @@ function(generateFMU modelIdentifier)
     set(multiValueArgs FMI_VERSIONS SOURCES LINK_TARGETS COMPILE_DEFINITIONS)
     cmake_parse_arguments(FMU "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+    set(fmuResultDir "${CMAKE_BINARY_DIR}/models")
+    if (NOT EXISTS "${fmuResultDir}")
+        file(MAKE_DIRECTORY "${fmuResultDir}")
+    endif ()
+
+    set(generatedSourcesDir "${CMAKE_BINARY_DIR}/generated")
+    if (NOT EXISTS "${generatedSourcesDir}")
+        file(MAKE_DIRECTORY "${generatedSourcesDir}")
+    endif ()
+
     if (NOT FMU_RESOURCE_FOLDER)
         set(FMU_RESOURCE_FOLDER "")
     endif ()

--- a/export/CMakeLists.txt
+++ b/export/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(generatedSourcesDir "${CMAKE_BINARY_DIR}/generated")
 
 add_subdirectory(src)
 


### PR DESCRIPTION
Enables using fmu4cpp from an external project using CMake Fetchcontent

```cmake
include(FetchContent)
FetchContent_Declare(
        fmu4cpp
        GIT_REPOSITORY https://github.com/Ecos-platform/fmu4cpp.git
        GIT_TAG c325c2c44d04cd6c512206acde0353cfd112b65a
)
FetchContent_MakeAvailable(fmu4cpp)
```

`generate_fmu` is now available